### PR TITLE
Feature: Add sub-check for Ingest Pipelines 

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,34 @@ CRITICAL - Total hits: 14074
  | total=14074;20;50
 ```
 
-## Further Documentation
+### Ingest
 
-* [Elasticsearch API Docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html)
-* [Elasticsearch SDK for Go](https://github.com/elastic/go-elasticsearch)
+Checks the ingest statistics of Ingest Pipelines. Thresholds check against errors of an Elasticsearch Ingest Pipeline.
+
+```
+Checks the ingest statistics of Ingest Pipelines
+
+Usage:
+  check_elasticsearch ingest [flags]
+
+Flags:
+      --pipeline string          Pipeline Name
+      --failed-warning string    Warning threshold for failed ingest operations. Use min:max for a range. (default "10")
+      --failed-critical string   Critical threshold for failed ingest operations. Use min:max for a range. (default "20")
+  -h, --help                     help for ingest
+```
+
+Examples:
+
+```
+check_elasticsearch ingest --failed-warning 5 --failed-critical 10
+WARNING - Ingest operations may not be alright
+  \_[WARNING] Failed ingest operations for mypipeline: 6; | pipelines.mypipeline.failed=6c
+
+check_elasticsearch ingest --pipeline foobar
+OK - Ingest operations alright
+  \_[OK] Failed ingest operations for foobar: 5; | pipelines.foobar.failed=5c
+```
 
 ## License
 

--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/NETWAYS/go-check"
+	"github.com/NETWAYS/go-check/perfdata"
+	"github.com/NETWAYS/go-check/result"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+// To store the CLI parameters
+type PipelineConfig struct {
+	PipelineName   string
+	FailedWarning  string
+	FailedCritical string
+}
+
+var cliPipelineConfig PipelineConfig
+
+var ingestCmd = &cobra.Command{
+	Use:   "ingest",
+	Short: "Checks the ingest statistics of Ingest Pipelines",
+	Long:  `Checks the ingest statistics of Ingest Pipelines`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var (
+			rc       int
+			output   string
+			perfList perfdata.PerfdataList
+		)
+
+		failedCrit, err := check.ParseThreshold(cliPipelineConfig.FailedCritical)
+		if err != nil {
+			check.ExitError(err)
+		}
+
+		failedWarn, err := check.ParseThreshold(cliPipelineConfig.FailedWarning)
+		if err != nil {
+			check.ExitError(err)
+		}
+
+		client := cliConfig.NewClient()
+
+		stats, err := client.NodeStats()
+		if err != nil {
+			check.ExitError(err)
+		}
+
+		// Calculate states capacity
+		cap := 0
+		for _, node := range stats.Nodes {
+			cap += len(node.Ingest.Pipelines)
+		}
+
+		states := make([]int, 0, cap)
+
+		// Check status for each pipeline
+		var summary strings.Builder
+
+		for _, node := range stats.Nodes {
+			for pipelineName, pp := range node.Ingest.Pipelines {
+
+				// Skip if pipeline name doesn't match
+				if cliPipelineConfig.PipelineName != "" {
+					if cliPipelineConfig.PipelineName != pipelineName {
+						continue
+					}
+				}
+
+				summary.WriteString("\n \\_")
+				if failedCrit.DoesViolate(pp.Failed) {
+					states = append(states, check.Critical)
+					summary.WriteString(fmt.Sprintf("[CRITICAL] Failed ingest operations for %s: %g;", pipelineName, pp.Failed))
+				} else if failedWarn.DoesViolate(pp.Failed) {
+					states = append(states, check.Warning)
+					summary.WriteString(fmt.Sprintf("[WARNING] Failed ingest operations for %s: %g;", pipelineName, pp.Failed))
+				} else {
+					states = append(states, check.OK)
+					summary.WriteString(fmt.Sprintf("[OK] Failed ingest operations for %s: %g;", pipelineName, pp.Failed))
+				}
+
+				perfList.Add(&perfdata.Perfdata{
+					Label: fmt.Sprintf("pipelines.%s.failed", pipelineName),
+					Uom:   "c",
+					Value: pp.Failed})
+				perfList.Add(&perfdata.Perfdata{
+					Label: fmt.Sprintf("pipelines.%s.count", pipelineName),
+					Uom:   "c",
+					Value: pp.Count})
+				perfList.Add(&perfdata.Perfdata{
+					Label: fmt.Sprintf("pipelines.%s.current", pipelineName),
+					Uom:   "c",
+					Value: pp.Current})
+			}
+		}
+
+		// Validate the various subchecks and use the worst state as return code
+		switch result.WorstState(states...) {
+		case 0:
+			rc = check.OK
+			output = "Ingest operations alright"
+		case 1:
+			rc = check.Warning
+			output = "Ingest operations may not be alright"
+		case 2:
+			rc = check.Critical
+			output = "Ingest operations not alright"
+		default:
+			rc = check.Unknown
+			output = "Ingest operations status unknown"
+		}
+
+		check.ExitRaw(rc, output, summary.String(), "|", perfList.String())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(ingestCmd)
+
+	fs := ingestCmd.Flags()
+
+	fs.StringVar(&cliPipelineConfig.PipelineName, "pipeline", "",
+		"Pipeline Name")
+
+	fs.StringVar(&cliPipelineConfig.FailedWarning, "failed-warning", "10",
+		"Warning threshold for failed ingest operations. Use min:max for a range.")
+	fs.StringVar(&cliPipelineConfig.FailedCritical, "failed-critical", "20",
+		"Critical threshold for failed ingest operations. Use min:max for a range.")
+
+	fs.SortFlags = false
+}

--- a/cmd/ingest_test.go
+++ b/cmd/ingest_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestIngest_ConnectionRefused(t *testing.T) {
+
+	cmd := exec.Command("go", "run", "../main.go", "ingest", "--port", "9999")
+	out, _ := cmd.CombinedOutput()
+
+	actual := string(out)
+	expected := "UNKNOWN - could not fetch cluster nodes statistics: Get \"http://localhost:9999/_nodes/stats\": dial"
+
+	if !strings.Contains(actual, expected) {
+		t.Error("\nActual: ", actual, "\nExpected: ", expected)
+	}
+}
+
+type IngestTest struct {
+	name     string
+	server   *httptest.Server
+	args     []string
+	expected string
+}
+
+func TestIngestCmd(t *testing.T) {
+	tests := []IngestTest{
+		{
+			name: "ingest-ok",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"_nodes":{"total":1,"successful":1,"failed":0},"cluster_name":"clustername","nodes":{"node1":{"ip":"127.0.0.1:9300","ingest":{"total":{"count":10,"time_in_millis":0,"current":3,"failed":5},"pipelines":{"mypipeline":{"count":10,"time_in_millis":0,"current":3,"failed":5,"processors":[{"set":{"type":"set","stats":{"count":0,"time_in_millis":0,"current":0,"failed":0}}}]}}}}}}`))
+			})),
+			args:     []string{"run", "../main.go", "ingest"},
+			expected: "OK - Ingest operations alright \n \\_[OK] Failed ingest operations for mypipeline: 5; | pipelines.mypipeline.failed=5c pipelines.mypipeline.count=10c pipelines.mypipeline.current=3c\n",
+		},
+		{
+			name: "ingest-ok-with-name",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"_nodes":{"total":1,"successful":1,"failed":0},"cluster_name":"clustername","nodes":{"mm3U-u0WTCeuZ325vZGY2w":{"ip":"127.0.0.1:9300","ingest":{"total":{"count":10,"time_in_millis":0,"current":3,"failed":5},"pipelines":{"foobar":{"count":10,"time_in_millis":0,"current":3,"failed":5,"processors":[{"set":{"type":"set","stats":{"count":0,"time_in_millis":0,"current":0,"failed":0}}}]},"mypipeline":{"count":10,"time_in_millis":0,"current":3,"failed":5,"processors":[{"set":{"type":"set","stats":{"count":0,"time_in_millis":0,"current":0,"failed":0}}}]}}}}}}`))
+			})),
+			args:     []string{"run", "../main.go", "ingest", "--pipeline", "foobar"},
+			expected: "OK - Ingest operations alright \n \\_[OK] Failed ingest operations for foobar: 5; | pipelines.foobar.failed=5c pipelines.foobar.count=10c pipelines.foobar.current=3c\n",
+		},
+		{
+			name: "ingest-warn",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"_nodes":{"total":1,"successful":1,"failed":0},"cluster_name":"clustername","nodes":{"node1":{"ip":"127.0.0.1:9300","ingest":{"total":{"count":10,"time_in_millis":0,"current":3,"failed":5},"pipelines":{"mypipeline":{"count":10,"time_in_millis":0,"current":3,"failed":5,"processors":[{"set":{"type":"set","stats":{"count":0,"time_in_millis":0,"current":0,"failed":0}}}]}}}}}}`))
+			})),
+			args:     []string{"run", "../main.go", "ingest", "--failed-warning", "3"},
+			expected: "WARNING - Ingest operations may not be alright \n \\_[WARNING] Failed ingest operations for mypipeline: 5; | pipelines.mypipeline.failed=5c pipelines.mypipeline.count=10c pipelines.mypipeline.current=3c\nexit status 1\n",
+		},
+		{
+			name: "ingest-crit",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"_nodes":{"total":1,"successful":1,"failed":0},"cluster_name":"clustername","nodes":{"node1":{"ip":"127.0.0.1:9300","ingest":{"total":{"count":10,"time_in_millis":0,"current":3,"failed":5},"pipelines":{"mypipeline":{"count":10,"time_in_millis":0,"current":3,"failed":5,"processors":[{"set":{"type":"set","stats":{"count":0,"time_in_millis":0,"current":0,"failed":0}}}]}}}}}}`))
+			})),
+			args:     []string{"run", "../main.go", "ingest", "--failed-critical", "3"},
+			expected: "CRITICAL - Ingest operations not alright \n \\_[CRITICAL] Failed ingest operations for mypipeline: 5; | pipelines.mypipeline.failed=5c pipelines.mypipeline.count=10c pipelines.mypipeline.current=3c\nexit status 2\n",
+		},
+		{
+			name: "ingest-invalid",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{}`))
+			})),
+			args:     []string{"run", "../main.go", "ingest"},
+			expected: "UNKNOWN - Ingest operations status unknown  | \nexit status 3\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			defer test.server.Close()
+
+			// We need the random Port extracted
+			u, _ := url.Parse(test.server.URL)
+			cmd := exec.Command("go", append(test.args, "--port", u.Port())...)
+			out, _ := cmd.CombinedOutput()
+
+			actual := string(out)
+
+			if actual != test.expected {
+				t.Error("\nActual: ", actual, "\nExpected: ", test.expected)
+			}
+
+		})
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -122,3 +122,30 @@ func (c *Client) SearchMessages(index string, query string, messageKey string) (
 
 	return
 }
+
+func (c *Client) NodeStats() (r *es.ClusterStats, err error) {
+	u, _ := url.JoinPath(c.Url, "/_nodes/stats")
+	resp, err := c.Client.Get(u)
+
+	if err != nil {
+		err = fmt.Errorf("could not fetch cluster nodes statistics: %w", err)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("request failed for cluster nodes statistics: %s", resp.Status)
+		return
+	}
+
+	r = &es.ClusterStats{}
+
+	defer resp.Body.Close()
+	err = json.NewDecoder(resp.Body).Decode(r)
+
+	if err != nil {
+		err = fmt.Errorf("could not decode nodes statistics json: %w", err)
+		return
+	}
+
+	return
+}

--- a/internal/elasticsearch/api.go
+++ b/internal/elasticsearch/api.go
@@ -52,3 +52,30 @@ type Query struct {
 type QueryString struct {
 	Query string `json:"query"`
 }
+
+type NodeInfo struct {
+	IP     string     `json:"ip"`
+	Ingest IngestInfo `json:"ingest"`
+}
+
+type IngestInfo struct {
+	Total     IngestStats             `json:"total"`
+	Pipelines map[string]PipelineInfo `json:"pipelines"`
+}
+
+type IngestStats struct {
+	Count   float64 `json:"count"`
+	Current float64 `json:"current"`
+	Failed  float64 `json:"failed"`
+}
+
+type PipelineInfo struct {
+	Count   float64 `json:"count"`
+	Current float64 `json:"current"`
+	Failed  float64 `json:"failed"`
+}
+
+type ClusterStats struct {
+	Nodes       map[string]NodeInfo `json:"nodes"`
+	ClusterName string              `json:"cluster_name"`
+}


### PR DESCRIPTION
Evaluates the Node Stats from the API and looks at the failed ingest operations. 

Design

```
check_elasticsearch ingest --failed-warning 3
WARNING - Ingest operations may not be alright 
  \_[WARNING] Failed ingest operations for mypipeline: 5; | pipelines.mypipeline.failed=5c 
pipelines.mypipeline.count=10c pipelines.mypipeline.current=3c

check_elasticsearch ingest --pipeline foobar
OK - Ingest operations alright 
  \_[OK] Failed ingest operations for foobar: 5; | pipelines.foobar.failed=5c pipelines.foobar.count=10c 
pipelines.foobar.current=3c
```

I used `--failed-warning` instead of `--warning` since we might want to add further flags, e.g. `--failed-count` to return warning on a given operations count. For now I think failed operations are a reasonable start.

Fixes #28 

TODO

- [x] Update README