### PR TITLE
Improve query error message

### DIFF
--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -50,7 +50,7 @@ func TestQueryCmd(t *testing.T) {
 				w.Write([]byte(`{"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [example]","resource.type":"index_or_alias","resource.id":"kibaa_sample_data_logs","index_uuid":"_na_","index":"example"}],"type":"index_not_found_exception","reason":"no such index [example]","resource.type":"index_or_alias","resource.id":"example","index_uuid":"_na_","index":"example"},"status":404}`))
 			})),
 			args:     []string{"run", "../main.go", "query", "-q", "foo", "-I", "foo"},
-			expected: "[UNKNOWN] - request failed for search: 404 Not Found (*errors.errorString)\nexit status 3\n",
+			expected: "[UNKNOWN] - failed to run query: no such index [example] (*errors.errorString)\nexit status 3\n",
 		},
 		{
 			name: "query-example",

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -112,11 +112,6 @@ func (c *Client) SearchMessages(index string, query string, messageKey string) (
 		return
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("request failed for search: %s", resp.Status)
-		return
-	}
-
 	var response es.SearchResponse
 
 	defer resp.Body.Close()
@@ -124,6 +119,13 @@ func (c *Client) SearchMessages(index string, query string, messageKey string) (
 
 	if err != nil {
 		err = fmt.Errorf("error parsing the response body: %w", err)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		queryErrors := response.GetErrors()
+		err = fmt.Errorf("failed to run query: %s", queryErrors)
+
 		return
 	}
 


### PR DESCRIPTION
Now includes the error reason when present:

```
go run main.go query -q "state: open AND " -k "state"
[UNKNOWN] - failed to run query: Failed to parse query [state: open AND ] (*errors.errorString)
exit status 3
```

Fixes #83 